### PR TITLE
Improve build logs, support of v5/latest enums

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,15 @@ on:
       branches:
         - pipeline
   workflow_dispatch: # This triggers the workflow when a webhook is received
-
+      inputs:
+        branch:
+          description: 'The branch of the submodule the workflow was triggered for'
+          required: true
+          type: string
+        repository:
+          description: 'The repository of the submodule the workflow was triggered for'
+          required: true
+          type: string
 
 jobs:
   build:
@@ -35,13 +43,19 @@ jobs:
 
     - name: Push to main
       run: |
-        cp -R target/* main
-        cd main
+        rsync -a --delete --exclude 'img/' target/ main/
+        cp README.md main/
+        cp LICENSE main/
+        cd main  
         git config --global user.email "openminds@ebrains.eu"
         git config --global user.name "openMINDS pipeline"
-        if [[ $(git add . --dry-run | wc -l) -gt 0 ]]; then
-            git add .
-            git commit -m "build triggered by submodule ${{ inputs.repository }} version ${{ inputs.branch }}"
+        if [[ $(git add -A --dry-run | wc -l) -gt 0 ]]; then
+            git add -A
+            if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+              git commit -m "build triggered by submodule ${{ inputs.repository }} version ${{ inputs.branch }}"
+            else
+              git commit -m "build triggered by ${{ github.event_name }}"
+            fi
             git push -f
         else
             echo "Nothing to commit"

--- a/build.py
+++ b/build.py
@@ -17,6 +17,7 @@ from pipeline.utils import clone_sources, SchemaLoader, InstanceLoader, get_shor
 terms_as_enums = True
 licenses_as_enums = True
 content_types_as_enums = True
+accessibilities_as_enums = True
 graph_structures_as_enums = True
 
 print("********************************************************")
@@ -78,9 +79,11 @@ for schema_version in schema_loader.get_schema_versions():
                 terms_as_enums and "controlled" in schema_file_path,
                 licenses_as_enums and "license" in schema_file_path,
                 content_types_as_enums and "contentType" in schema_file_path,
+                accessibilities_as_enums and "accessibility" in schema_file_path,
                 graph_structures_as_enums
                 and (
                     "parcellationEntity" in schema_file_path
+                    or "commonCoordinateFramework" in schema_file_path
                     or "commonCoordinateSpace" in schema_file_path
                 ),
             ]


### PR DESCRIPTION
Added inputs for branch and repository to workflow dispatch.
Introduced rsync instead of cp.
Support v5/latest enums.

Note: it should delete the following deprecated enums folder https://github.com/openMetadataInitiative/openMINDS_LinkML/tree/main/enums/latest/controlledTerms 